### PR TITLE
Fix typos in architecture messages

### DIFF
--- a/dev/make/identify_os.sh
+++ b/dev/make/identify_os.sh
@@ -23,7 +23,7 @@ if [ "${os}" = "Linux" ]; then
   elif [ "${ARCH}" = "aarch64" ]; then
     echo lnxarm
   else
-    echo "Unkown architecture: ${ARCH}"
+    echo "Unknown architecture: ${ARCH}"
     exit 1
   fi
 elif [ "${os}" = "Darwin" ]; then

--- a/examples/cmake/setup_examples.cmake
+++ b/examples/cmake/setup_examples.cmake
@@ -111,7 +111,7 @@ function (add_examples examples_paths)
         elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
             set(CPU_ARCHITECTURE "riscv64_riscv64")
         else()
-            message(FATAL_ERROR "Unkown architecture ${CMAKE_SYSTEM_PROCESSOR}")
+            message(FATAL_ERROR "Unknown architecture ${CMAKE_SYSTEM_PROCESSOR}")
         endif()
 
         add_executable(${example} ${example_file_path})

--- a/samples/cmake/setup_samples.cmake
+++ b/samples/cmake/setup_samples.cmake
@@ -90,7 +90,7 @@ function(add_samples samples_paths)
         elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
             set(CPU_ARCHITECTURE "arm_aarch64")
         else()
-            message(FATAL_ERROR "Unkown architecture ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+            message(FATAL_ERROR "Unknown architecture ${CMAKE_HOST_SYSTEM_PROCESSOR}")
         endif()
 
         add_executable(${sample} ${sample_file_path})


### PR DESCRIPTION
## Summary
- fix typos in "Unknown architecture" messages across build scripts

## Testing
- `bash dev/make/identify_os.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840e7797e8c832b804708d05aed24a8